### PR TITLE
Feat/improve provider interaction status

### DIFF
--- a/resources/lang/en/parking-hub.php
+++ b/resources/lang/en/parking-hub.php
@@ -11,6 +11,9 @@ return [
         'ERROR_PROVIDER_AUTHENTICATION' => 'Authentication error',
         'ERROR_INVALID_PLATE_FORMAT_FOR_PROVIDER' => 'Invalid plate format for provider',
         'ERROR_PROVIDER_BAD_REQUEST' => 'Bad request to provider',
+        'ERROR_PROVIDER_CONFIGURATION' => 'Provider configuration error',
+        'ERROR_CONNECTION_TIMEOUT' => 'Connection timeout',
+        'ERROR_INVALID_RESPONSE' => 'Invalid response from provider',
         'ERROR_PROVIDER_UNKNOWN' => 'Unknown error from provider',
     ],
 ];

--- a/resources/lang/it/parking-hub.php
+++ b/resources/lang/it/parking-hub.php
@@ -11,6 +11,9 @@ return [
         'ERROR_PROVIDER_AUTHENTICATION' => 'Errore di autenticazione',
         'ERROR_INVALID_PLATE_FORMAT_FOR_PROVIDER' => 'Formato targa non valido per il fornitore',
         'ERROR_PROVIDER_BAD_REQUEST' => 'Richiesta non valida al fornitore',
+        'ERROR_PROVIDER_CONFIGURATION' => 'Errore di configurazione del fornitore',
+        'ERROR_CONNECTION_TIMEOUT' => 'Timeout di connessione',
+        'ERROR_INVALID_RESPONSE' => 'Risposta non valida dal fornitore',
         'ERROR_PROVIDER_UNKNOWN' => 'Errore sconosciuto dal fornitore',
     ],
 ];

--- a/src/Contracts/ParkingValidator.php
+++ b/src/Contracts/ParkingValidator.php
@@ -26,10 +26,10 @@ interface ParkingValidator
      * 4. Setting the 'requestTimestamp' in the DTO to the moment this check begins processing.
      *
      * @param  string  $plateNumber  the license plate number to check
-     * @param  CarbonInterface  $verificationDateTime  the date and time for which the parking validity is checked
+     * @param  ?CarbonInterface  $verificationDateTime  the date and time for which the parking validity is checked. When is null, the current date and time should be used.
      */
     public function checkPlate(
         string $plateNumber,
-        CarbonInterface $verificationDateTime
+        ?CarbonInterface $verificationDateTime
     ): ParkingValidationResponseData;
 }

--- a/src/Enums/ProviderInteractionStatus.php
+++ b/src/Enums/ProviderInteractionStatus.php
@@ -12,6 +12,9 @@ enum ProviderInteractionStatus: string
     case ERROR_PROVIDER_AUTHENTICATION = 'ERROR_PROVIDER_AUTHENTICATION';
     case ERROR_INVALID_PLATE_FORMAT_FOR_PROVIDER = 'ERROR_INVALID_PLATE_FORMAT_FOR_PROVIDER';
     case ERROR_PROVIDER_BAD_REQUEST = 'ERROR_PROVIDER_BAD_REQUEST';
+    case ERROR_PROVIDER_CONFIGURATION = 'ERROR_PROVIDER_CONFIGURATION';
+    case ERROR_CONNECTION_TIMEOUT = 'ERROR_CONNECTION_TIMEOUT';
+    case ERROR_INVALID_RESPONSE = 'ERROR_INVALID_RESPONSE';
     case ERROR_PROVIDER_UNKNOWN = 'ERROR_PROVIDER_UNKNOWN';
 
     public function getDescription(): string
@@ -23,6 +26,9 @@ enum ProviderInteractionStatus: string
             self::ERROR_PROVIDER_AUTHENTICATION => __('oltrematica-parking-hub::parking-hub.provider-interaction-status.ERROR_PROVIDER_AUTHENTICATION'),
             self::ERROR_INVALID_PLATE_FORMAT_FOR_PROVIDER => __('oltrematica-parking-hub::parking-hub.provider-interaction-status.ERROR_INVALID_PLATE_FORMAT_FOR_PROVIDER'),
             self::ERROR_PROVIDER_BAD_REQUEST => __('oltrematica-parking-hub::parking-hub.provider-interaction-status.ERROR_PROVIDER_BAD_REQUEST'),
+            self::ERROR_PROVIDER_CONFIGURATION => __('oltrematica-parking-hub::parking-hub.provider-interaction-status.ERROR_PROVIDER_CONFIGURATION'),
+            self::ERROR_CONNECTION_TIMEOUT => __('oltrematica-parking-hub::parking-hub.provider-interaction-status.ERROR_CONNECTION_TIMEOUT'),
+            self::ERROR_INVALID_RESPONSE => __('oltrematica-parking-hub::parking-hub.provider-interaction-status.ERROR_INVALID_RESPONSE'),
             self::ERROR_PROVIDER_UNKNOWN => __('oltrematica-parking-hub::parking-hub.provider-interaction-status.ERROR_PROVIDER_UNKNOWN'),
         };
     }
@@ -42,6 +48,9 @@ enum ProviderInteractionStatus: string
             self::ERROR_PROVIDER_AUTHENTICATION,
             self::ERROR_INVALID_PLATE_FORMAT_FOR_PROVIDER,
             self::ERROR_PROVIDER_BAD_REQUEST,
+            self::ERROR_PROVIDER_CONFIGURATION,
+            self::ERROR_CONNECTION_TIMEOUT,
+            self::ERROR_INVALID_RESPONSE,
             self::ERROR_PROVIDER_UNKNOWN => true,
             default => false,
         };

--- a/tests/Unit/DTOs/ParkingValidationResponseDataTest.php
+++ b/tests/Unit/DTOs/ParkingValidationResponseDataTest.php
@@ -60,6 +60,9 @@ describe('ParkingValidationResponseData - buildFailure', function (): void {
         'ERROR_PROVIDER_AUTHENTICATION' => ProviderInteractionStatus::ERROR_PROVIDER_AUTHENTICATION,
         'ERROR_INVALID_PLATE_FORMAT_FOR_PROVIDER' => ProviderInteractionStatus::ERROR_INVALID_PLATE_FORMAT_FOR_PROVIDER,
         'ERROR_PROVIDER_BAD_REQUEST' => ProviderInteractionStatus::ERROR_PROVIDER_BAD_REQUEST,
+        'ERROR_PROVIDER_CONFIGURATION' => ProviderInteractionStatus::ERROR_PROVIDER_CONFIGURATION,
+        'ERROR_CONNECTION_TIMEOUT' => ProviderInteractionStatus::ERROR_CONNECTION_TIMEOUT,
+        'ERROR_INVALID_RESPONSE' => ProviderInteractionStatus::ERROR_INVALID_RESPONSE,
         'ERROR_PROVIDER_UNKNOWN' => ProviderInteractionStatus::ERROR_PROVIDER_UNKNOWN,
     ]);
 

--- a/tests/Unit/Support/Manager/ParkingHubManagerTest.php
+++ b/tests/Unit/Support/Manager/ParkingHubManagerTest.php
@@ -48,7 +48,7 @@ describe('ParkingHubManager - createDriver', function (): void {
         $driverName = 'valid_driver';
         $driverClass = new class([]) implements ParkingValidator
         {
-            public function checkPlate(string $plateNumber, Carbon\CarbonInterface $verificationDateTime): Oltrematica\ParkingHub\DTOs\ParkingValidationResponseData {}
+            public function checkPlate(string $plateNumber, ?Carbon\CarbonInterface $verificationDateTime): Oltrematica\ParkingHub\DTOs\ParkingValidationResponseData {}
         };
         Config::set("parking-hub.drivers.{$driverName}", ['class' => $driverClass::class]);
 
@@ -130,7 +130,7 @@ if (! class_exists('TestConfigurableDriver')) {
     {
         public function __construct(private readonly array $config) {}
 
-        public function checkPlate(string $plateNumber, Carbon\CarbonInterface $verificationDateTime): Oltrematica\ParkingHub\DTOs\ParkingValidationResponseData
+        public function checkPlate(string $plateNumber, ?Carbon\CarbonInterface $verificationDateTime): Oltrematica\ParkingHub\DTOs\ParkingValidationResponseData
         {
             // Dummy implementation
             return new Oltrematica\ParkingHub\DTOs\ParkingValidationResponseData(


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the parking hub system, including new error types, updates to the `ParkingValidator` interface, and corresponding test adjustments. These changes improve error handling, make the interface more flexible, and ensure proper test coverage.

### Error Handling Enhancements:
* Added new error types (`ERROR_PROVIDER_CONFIGURATION`, `ERROR_CONNECTION_TIMEOUT`, `ERROR_INVALID_RESPONSE`) to the language files (`resources/lang/en/parking-hub.php` and `resources/lang/it/parking-hub.php`) for better localization support. [[1]](diffhunk://#diff-a60f708bb65cdf5f94df5fb1eb4752daadb3447f80a8f93ed907463b4142c147R14-R16) [[2]](diffhunk://#diff-732d32a701e0aa46d36b7faf1895e91c691231bb5699082af911a63ef8d8adb5R14-R16)
* Updated the `ProviderInteractionStatus` enum to include the new error types, along with their descriptions and error-checking logic in the `getDescription` and `isError` methods. [[1]](diffhunk://#diff-df06d9e2f60a605a64a86ec55f1ff55d93b0d928615b4a00a971d984a5a810aeR15-R17) [[2]](diffhunk://#diff-df06d9e2f60a605a64a86ec55f1ff55d93b0d928615b4a00a971d984a5a810aeR29-R31) [[3]](diffhunk://#diff-df06d9e2f60a605a64a86ec55f1ff55d93b0d928615b4a00a971d984a5a810aeR51-R53)

### Interface and Implementation Updates:
* Modified the `ParkingValidator` interface to allow `null` for the `verificationDateTime` parameter, defaulting to the current date and time when not provided. This change was applied to both the interface and its implementations. [[1]](diffhunk://#diff-add0035895edda8755e55a4eb566333804f91a0e8726a820248045a27687dd96L29-R33) [[2]](diffhunk://#diff-1ff4cf85eac3ed8e1b4e6a657bd687cacb9e606502da3aba4910b13e3155e32bL51-R51) [[3]](diffhunk://#diff-1ff4cf85eac3ed8e1b4e6a657bd687cacb9e606502da3aba4910b13e3155e32bL133-R133)

### Test Coverage Improvements:
* Updated unit tests to reflect the new error types in `ParkingValidationResponseDataTest` and `ParkingHubManagerTest`, ensuring comprehensive test coverage for the changes. [[1]](diffhunk://#diff-0f75a48e25035401f32952f18ec2aa35c5e04101c542f6e6993914aa248a099cR63-R65) [[2]](diffhunk://#diff-1ff4cf85eac3ed8e1b4e6a657bd687cacb9e606502da3aba4910b13e3155e32bL51-R51) [[3]](diffhunk://#diff-1ff4cf85eac3ed8e1b4e6a657bd687cacb9e606502da3aba4910b13e3155e32bL133-R133)