### PR TITLE
feat: refactor buildFailure method to be static in ParkingValidationR…

### DIFF
--- a/src/DTOs/ParkingValidationResponseData.php
+++ b/src/DTOs/ParkingValidationResponseData.php
@@ -37,7 +37,7 @@ class ParkingValidationResponseData extends Data
      *
      * @return self DTO instance with success status
      */
-    public function buildFailure(ProviderInteractionStatus $interactionStatus, string $plate, CarbonInterface $requestTimestamp, ?CarbonInterface $verifcationTimestamp): self
+    public static function buildFailure(ProviderInteractionStatus $interactionStatus, string $plate, CarbonInterface $requestTimestamp, ?CarbonInterface $verifcationTimestamp): self
     {
         if ($interactionStatus->isSuccess()) {
             throw new InvalidArgumentException(

--- a/tests/Unit/DTOs/ParkingValidationResponseDataTest.php
+++ b/tests/Unit/DTOs/ParkingValidationResponseDataTest.php
@@ -15,15 +15,7 @@ describe('ParkingValidationResponseData - buildFailure', function (): void {
         $plate = 'AA123BB';
         $requestTimestamp = Carbon::now();
 
-        expect(fn (): ParkingValidationResponseData => (new ParkingValidationResponseData(
-            responseStatus: ProviderInteractionStatus::SUCCESS_OK, // Dummy initial status, not used by buildFailure directly
-            plate: $plate,
-            requestTimestamp: $requestTimestamp,
-            verificationTimestamp: $requestTimestamp,
-            isValid: true,
-            parkingEndTime: null,
-            purchasedParkings: null
-        ))->buildFailure($successStatus, $plate, $requestTimestamp, null))
+        expect(fn (): ParkingValidationResponseData => ParkingValidationResponseData::buildFailure($successStatus, $plate, $requestTimestamp, null))
             ->toThrow(InvalidArgumentException::class, 'Interaction status is success, but the response indicates failure.');
     })->with([
         'SUCCESS_OK' => ProviderInteractionStatus::SUCCESS_OK,
@@ -35,15 +27,7 @@ describe('ParkingValidationResponseData - buildFailure', function (): void {
         $requestTimestamp = Carbon::parse('2023-01-01 10:00:00');
         $verificationTimestamp = Carbon::parse('2023-01-01 10:05:00');
 
-        $dto = (new ParkingValidationResponseData(
-            responseStatus: ProviderInteractionStatus::SUCCESS_OK, // Dummy initial status
-            plate: $plate,
-            requestTimestamp: $requestTimestamp,
-            verificationTimestamp: $requestTimestamp,
-            isValid: true,
-            parkingEndTime: null,
-            purchasedParkings: null
-        ))->buildFailure($errorStatus, $plate, $requestTimestamp, $verificationTimestamp);
+        $dto = ParkingValidationResponseData::buildFailure($errorStatus, $plate, $requestTimestamp, $verificationTimestamp);
 
         expect($dto)->toBeInstanceOf(ParkingValidationResponseData::class)
             ->and($dto->responseStatus)->toBe($errorStatus)
@@ -71,15 +55,7 @@ describe('ParkingValidationResponseData - buildFailure', function (): void {
         $requestTimestamp = Carbon::parse('2023-02-01 12:00:00');
         $errorStatus = ProviderInteractionStatus::ERROR_PROVIDER_UNAVAILABLE;
 
-        $dto = (new ParkingValidationResponseData(
-            responseStatus: ProviderInteractionStatus::SUCCESS_OK, // Dummy initial status
-            plate: $plate,
-            requestTimestamp: $requestTimestamp,
-            verificationTimestamp: $requestTimestamp,
-            isValid: true,
-            parkingEndTime: null,
-            purchasedParkings: null
-        ))->buildFailure($errorStatus, $plate, $requestTimestamp, null);
+        $dto = ParkingValidationResponseData::buildFailure($errorStatus, $plate, $requestTimestamp, null);
 
         expect($dto->verificationTimestamp)->toBeInstanceOf(CarbonInterface::class)
             ->and($dto->verificationTimestamp->equalTo($requestTimestamp))->toBeTrue();


### PR DESCRIPTION
This pull request refactors the `buildFailure` method in the `ParkingValidationResponseData` class to be a static method and updates the associated unit tests to align with this change. This simplifies the method usage and eliminates the need to instantiate the class before calling `buildFailure`.

### Refactoring of `buildFailure` Method:

* [`src/DTOs/ParkingValidationResponseData.php`](diffhunk://#diff-d4aad4ff813a114739c0a415b0911a3624a7a30ada44f869f39233cbf7235698L40-R40): Changed the `buildFailure` method from an instance method to a static method, allowing it to be called directly on the class without requiring an instance.

### Updates to Unit Tests:

* [`tests/Unit/DTOs/ParkingValidationResponseDataTest.php`](diffhunk://#diff-0f75a48e25035401f32952f18ec2aa35c5e04101c542f6e6993914aa248a099cL18-R18): Updated all test cases to call `ParkingValidationResponseData::buildFailure` statically instead of instantiating the class and then calling the method. This change simplifies the test setup and ensures consistency with the new method signature. [[1]](diffhunk://#diff-0f75a48e25035401f32952f18ec2aa35c5e04101c542f6e6993914aa248a099cL18-R18) [[2]](diffhunk://#diff-0f75a48e25035401f32952f18ec2aa35c5e04101c542f6e6993914aa248a099cL38-R30) [[3]](diffhunk://#diff-0f75a48e25035401f32952f18ec2aa35c5e04101c542f6e6993914aa248a099cL74-R58)…esponseData