### PR TITLE
feat: add findClosestParkingRange method to ParkingValidationResponse…

### DIFF
--- a/src/DTOs/ParkingValidationResponseData.php
+++ b/src/DTOs/ParkingValidationResponseData.php
@@ -37,8 +37,12 @@ class ParkingValidationResponseData extends Data
      *
      * @return self DTO instance with success status
      */
-    public static function buildFailure(ProviderInteractionStatus $interactionStatus, string $plate, CarbonInterface $requestTimestamp, ?CarbonInterface $verifcationTimestamp): self
-    {
+    public static function buildFailure(
+        ProviderInteractionStatus $interactionStatus,
+        string $plate,
+        CarbonInterface $requestTimestamp,
+        ?CarbonInterface $verifcationTimestamp
+    ): self {
         if ($interactionStatus->isSuccess()) {
             throw new InvalidArgumentException(
                 'Interaction status is success, but the response indicates failure.'
@@ -54,5 +58,88 @@ class ParkingValidationResponseData extends Data
             parkingEndTime: null,
             purchasedParkings: null
         );
+    }
+
+    /**
+     * Finds the parking range closest to the given timestamp and calculates any overflow
+     *
+     * @param  CarbonInterface  $currentTime  timestamp reference
+     * @return array{
+     *     parking: PurchasedParkingData|null,
+     *     duration_minutes: int|null,
+     *     overflow_minutes: int|null,
+     *     is_expired: bool
+     * }
+     */
+    public function findClosestParkingRange(CarbonInterface $currentTime): array
+    {
+        if ($this->purchasedParkings === null || $this->purchasedParkings === []) {
+            return [
+                'parking' => null,
+                'duration_minutes' => null,
+                'overflow_minutes' => null,
+                'is_expired' => false,
+            ];
+        }
+
+        $closestParking = null;
+        $minDistance = PHP_INT_MAX;
+
+        // find the closest purchased parking to verification date (excluding future parkings)
+        foreach ($this->purchasedParkings as $parking) {
+            // skip parkings that haven't started yet
+            if ($currentTime->isBefore($parking->startDateTime)) {
+                continue;
+            }
+
+            $distance = $this->calculateDistanceFromRange($currentTime, $parking);
+
+            if ($distance < $minDistance) {
+                $minDistance = $distance;
+                $closestParking = $parking;
+            }
+        }
+
+        if ($closestParking === null) {
+            return [
+                'parking' => null,
+                'duration_minutes' => null,
+                'overflow_minutes' => null,
+                'is_expired' => false,
+            ];
+        }
+
+        $durationMinutes = (int) $closestParking->startDateTime->diffInMinutes($closestParking->endDateTime);
+
+        $overflowMinutes = null;
+        $isExpired = false;
+
+        if ($currentTime->isAfter($closestParking->endDateTime)) {
+            $overflowMinutes = (int) $closestParking->endDateTime->diffInMinutes($currentTime);
+            $isExpired = true;
+        } else {
+            $overflowMinutes = 0;
+        }
+
+        return [
+            'parking' => $closestParking,
+            'duration_minutes' => $durationMinutes,
+            'overflow_minutes' => $overflowMinutes,
+            'is_expired' => $isExpired,
+        ];
+    }
+
+    /**
+     * Calculates the minimum distance between a timestamp and a parking range
+     */
+    private function calculateDistanceFromRange(CarbonInterface $timestamp, PurchasedParkingData $parking): int
+    {
+        // if timestamp is within the parking range, distance is 0
+        if ($timestamp->between($parking->startDateTime, $parking->endDateTime)) {
+            return 0;
+        }
+
+        // if timestamp is after the parking end, return the distance from end time
+        return (int) round($parking->endDateTime->diffInMinutes($timestamp), 0);
     }
 }


### PR DESCRIPTION
This pull request introduces a new method, `findClosestParkingRange`, in the `ParkingValidationResponseData` class to identify the closest parking range relative to a given timestamp and calculate related metrics such as duration, overflow minutes, and expiration status. Additionally, it includes comprehensive unit tests to verify the behavior of this method across various scenarios.

### Changes to `ParkingValidationResponseData` class:

* Added the `findClosestParkingRange` method to determine the closest parking range and compute metrics like duration, overflow minutes, and expiration status. It handles cases such as no purchased parkings, future parkings, and edge scenarios like parking starting or ending exactly at the current time.
* Introduced a private helper method, `calculateDistanceFromRange`, to compute the distance between a timestamp and a parking range.

### Unit tests for `ParkingValidationResponseData`:

* Added tests in `ParkingValidationResponseDataTest.php` to validate the behavior of the `findClosestParkingRange` method, including scenarios with no parkings, expired parkings, active parkings, future parkings, and edge cases.
* Imported the `PurchasedParkingData` class in the test file for constructing parking instances used in the tests.…Data